### PR TITLE
Fix %hs format specifier for Linux build compatibility

### DIFF
--- a/xml.cpp
+++ b/xml.cpp
@@ -892,7 +892,7 @@ FetchConfigurationVersion(
 	pugi::xml_parse_result parseResult = doc.load_file( fileName, pugi::parse_default | pugi::parse_declaration, pugEncoding );
 	if( !parseResult ) {
 
-		_tprintf( _T( "Error: Failed to load or parse xml configuration: %s (%hs at offset %td)\n" ),
+		_tprintf( _T( "Error: Failed to load or parse xml configuration: %s (%s at offset %td)\n" ),
 					  FileName,
 					  parseResult.description(),
 					  parseResult.offset );


### PR DESCRIPTION
%hs is MSVC-specific and causes -Werror build failure on Linux/gcc. Replace with %s since parseResult.description() returns a narrow string and _tprintf maps to printf on Linux.